### PR TITLE
feat: wire TypeOrmModule.forRootAsync and ValidationPipe in AppModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { envValidationSchema } from './config/env.validation';
+import { User } from './users/entities/user.entity';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -10,6 +13,21 @@ import { envValidationSchema } from './config/env.validation';
       isGlobal: true,
       validationSchema: envValidationSchema,
     }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        type: 'postgres',
+        url: config.get<string>('DATABASE_URL'),
+        entities: [User],
+        synchronize: config.get<string>('NODE_ENV') !== 'production',
+        ssl:
+          config.get<string>('NODE_ENV') === 'production'
+            ? { rejectUnauthorized: false }
+            : false,
+      }),
+    }),
+    UsersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   await app.listen(process.env.PORT ?? 3030);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
Wires `TypeOrmModule.forRootAsync()` into `AppModule` using `ConfigService` and enables global `ValidationPipe` in `main.ts`.

## Changes
- `src/app.module.ts` — added `TypeOrmModule.forRootAsync` (reads `DATABASE_URL` via ConfigService, registers `User` entity, enables `synchronize` in non-production, SSL in production) + imported `UsersModule`
- `src/main.ts` — enabled global `ValidationPipe` with `whitelist` and `transform`

## Testing
`bun run test` — all passing.

Closes #8