### PR TITLE
feat: GET /user/profile endpoint protected by JwtAuthGuard

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { UsersService } from './users.service';
+import { JwtPayload } from '../auth/strategies/jwt.strategy';
+import { User } from './entities/user.entity';
+
+@Controller('user')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('profile')
+  async getProfile(@Req() req: Request): Promise<Omit<User, 'refreshToken'>> {
+    const payload = req.user as JwtPayload;
+    const user = await this.usersService.findById(payload.sub);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { refreshToken: _, ...profile } = user;
+    return profile;
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
-  exports: [TypeOrmModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [TypeOrmModule, UsersService],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './entities/user.entity';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async findById(id: string): Promise<User> {
+    const user = await this.usersRepository.findOne({ where: { id } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    return user;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `GET /user/profile` that returns the authenticated user's info (excluding `refreshToken`).

## Changes
- `src/users/users.service.ts` — `findById()` looks up User by id, throws `NotFoundException` if not found
- `src/users/users.controller.ts` — `GET /user/profile` extracts `sub` from JWT payload, loads full User, strips `refreshToken` before returning
- `src/users/users.module.ts` — wired `UsersController` and `UsersService`, exported `UsersService`

## Response includes
`id`, `googleId`, `email`, `displayName`, `fcmToken`, `loyaltyPoints`, `lifetimePoints`, `currentTier`, `purchaseCount`, `currentStampCount`, `createdAt`

## Auth
Protected by global `JwtAuthGuard` — no `@Public()` decorator.

## Testing
`bun run test` — all passing.

Closes #13